### PR TITLE
Add version 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
     "fthx"
   ],
   "shell-version": [
-    "40"
+    "40", "41"
   ],
   "url": "https://github.com/fthx/no-overview",
   "uuid": "no-overview@fthx",


### PR DESCRIPTION
gnome-shell-41-beta is now available.