### PR TITLE
Add gnome-shell-43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -13,5 +13,5 @@
   ],
   "url": "https://github.com/fthx/no-overview",
   "uuid": "no-overview@fthx",
-  "version": 11
+  "version": 12
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/fthx/no-overview",
   "uuid": "no-overview@fthx",


### PR DESCRIPTION
This pull adds gnome-shell 43 to the compatibility list and increases the extension version. no-overview still works fine for vanilla gnome and the gjs documentation does not mention any breaking changes relevant to this extension (See: https://gjs.guide/extensions/upgrading/gnome-shell-43.html#quick-settings).